### PR TITLE
feat: make claude-code buffer unlisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `split_ratio` config option to replace `height_ratio` for better handling of both horizontal and vertical splits
+- Buffer is now unlisted by default (doesn't appear in `:ls` output)
 
 ### Fixed
 - Fixed vertical split behavior when the window position is set to a vertical split command

--- a/lua/claude-code/terminal.lua
+++ b/lua/claude-code/terminal.lua
@@ -108,6 +108,7 @@ function M.toggle(claude_code, config, git)
 
     vim.cmd(cmd)
     vim.cmd 'setlocal bufhidden=hide'
+    vim.cmd 'setlocal nobuflisted'
     vim.cmd 'file claude-code'
 
     if config.window.hide_numbers then

--- a/tests/spec/terminal_spec.lua
+++ b/tests/spec/terminal_spec.lua
@@ -290,4 +290,25 @@ describe('terminal module', function()
       assert.is_true(success, 'Force insert mode function should run without error')
     end)
   end)
+
+  describe('buffer listing', function()
+    it('should set buffer as nobuflisted when creating terminal', function()
+      -- Claude Code is not running (bufnr is nil)
+      claude_code.claude_code.bufnr = nil
+
+      -- Call toggle
+      terminal.toggle(claude_code, config, git)
+
+      -- Check that nobuflisted command was called
+      local nobuflisted_found = false
+      for _, cmd in ipairs(vim_cmd_calls) do
+        if cmd == 'setlocal nobuflisted' then
+          nobuflisted_found = true
+          break
+        end
+      end
+
+      assert.is_true(nobuflisted_found, 'setlocal nobuflisted should be called')
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary
- Prevents claude-code terminal buffer from appearing in buffer lists (`:ls`, `:buffers`)
- Adds test coverage for the `nobuflisted` functionality

## Test plan
- [x] Run existing test suite (`./scripts/test.sh`) - all tests pass
- [x] Manual testing: 
  - Open claude-code with `:ClaudeCode`
  - Check buffer list with `:ls` - claude-code buffer should not appear
  - Toggle claude-code visibility - buffer remains unlisted

🤖 Generated with [Claude Code](https://claude.ai/code)